### PR TITLE
Dashboard de saldos por período

### DIFF
--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/ContaController.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/ContaController.java
@@ -24,7 +24,6 @@ public class ContaController {
 
     @GetMapping
     public List<ContaDTO> findAll(@RequestParam("data") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate data) {
-
         String idUsuario = usuarioService.getUsuarioLogadoId();
 
         return contaService.findAll(idUsuario, data);

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashBoards/DashBoardController.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashBoards/DashBoardController.java
@@ -26,24 +26,28 @@ public class DashBoardController {
     private TransacoesDashboardsService transacoesDashboardsService;
 
     @GetMapping("/despesasCategoria")
-    public List<CategoriaMinDTO> getDespesasCategorias(@RequestParam("data") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate data) {
-        try {
-            String userId = usuarioService.getUsuarioLogadoId();
-            return categoriaDashboardService.findAllValorTotalCategoria(userId, data, TipoTransacao.DESPESA);
-        }catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+    public List<CategoriaMinDTO> getDespesasCategorias(@RequestParam int ano, @RequestParam int mes){
+        LocalDate data = LocalDate.of(ano, mes, 1);
+        data = data.with(TemporalAdjusters.lastDayOfMonth());
+
+        String userId = usuarioService.getUsuarioLogadoId();
+        return categoriaDashboardService.findAllValorTotalCategoria(userId, data, TipoTransacao.DESPESA);
     }
 
     @GetMapping("/receitasCategoria")
-    public List<CategoriaMinDTO> getReceitasCategorias(@RequestParam("data") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate data) {
+    public List<CategoriaMinDTO> getReceitasCategorias(@RequestParam int ano, @RequestParam int mes){
+        LocalDate data = LocalDate.of(ano, mes, 1);
+        data = data.with(TemporalAdjusters.lastDayOfMonth());
+
         String userId = usuarioService.getUsuarioLogadoId();
         return categoriaDashboardService.findAllValorTotalCategoria(userId, data, TipoTransacao.RECEITA);
     }
 
     @GetMapping("/categoria/{id}")
-    public CategoriaExpandedDTO getExpandedCategoria(@PathVariable Long id, @RequestParam("data") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate data){
+    public CategoriaExpandedDTO getExpandedCategoria(@PathVariable Long id, @RequestParam int ano, @RequestParam int mes){
+        LocalDate data = LocalDate.of(ano, mes, 1);
+        data = data.with(TemporalAdjusters.lastDayOfMonth());
+
         String userId = usuarioService.getUsuarioLogadoId();
         return categoriaDashboardService.findExpandedCategoria(userId, id, data);
     }

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/CategoriaDadosService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/CategoriaDadosService.java
@@ -1,15 +1,14 @@
-package com.projetointegrado.MeuBolso.dashBoards;
+package com.projetointegrado.MeuBolso.dashboard;
 
 import com.projetointegrado.MeuBolso.categoria.*;
-import com.projetointegrado.MeuBolso.dashBoards.dto.CategoriaDadosDTO;
-import com.projetointegrado.MeuBolso.dashBoards.dto.CategoriaExpandedDTO;
+import com.projetointegrado.MeuBolso.dashboard.dto.CategoriaDadosDTO;
+import com.projetointegrado.MeuBolso.dashboard.dto.CategoriaExpandedDTO;
 import com.projetointegrado.MeuBolso.transacao.TipoTransacao;
 import com.projetointegrado.MeuBolso.transacao.Transacao;
 import com.projetointegrado.MeuBolso.transacao.TransacaoRepository;
 import com.projetointegrado.MeuBolso.transacao.TransacaoService;
 import com.projetointegrado.MeuBolso.transacao.dto.TransacaoDTO;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/CategoriaDadosService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/CategoriaDadosService.java
@@ -25,13 +25,7 @@ public class CategoriaDadosService {
     private CategoriaRepository categoriaRepository;
 
     @Autowired
-    private ICategoriaService categoriaService;
-
-    @Autowired
     private TransacaoRepository transacaoRepository;
-
-    @Autowired
-    private TransacaoService transacaoService;
 
     @Transactional
     public List<CategoriaDadosDTO> getDadosCategorias(String userId, LocalDate dataFinal, TipoTransacao tipo) {
@@ -73,4 +67,3 @@ public class CategoriaDadosService {
         return new CategoriaDadosDTO(categoria, valorCategoria, prctGasto);
     }
 }
-//CategoriaDadosDTO dto = getCategoriaDadosDTO(userId, dataInicial, dataFinal, tipoCategoria, categoria);

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/CategoriaDashboardService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/CategoriaDashboardService.java
@@ -1,11 +1,10 @@
-package com.projetointegrado.MeuBolso.dashBoards;
+package com.projetointegrado.MeuBolso.dashboard;
 
 import com.projetointegrado.MeuBolso.categoria.Categoria;
 import com.projetointegrado.MeuBolso.categoria.CategoriaValidateService;
-import com.projetointegrado.MeuBolso.categoria.TipoCategoria;
-import com.projetointegrado.MeuBolso.dashBoards.dto.CategoriaDadosDTO;
-import com.projetointegrado.MeuBolso.dashBoards.dto.CategoriaExpandedDTO;
-import com.projetointegrado.MeuBolso.dashBoards.dto.CategoriaMinDTO;
+import com.projetointegrado.MeuBolso.dashboard.dto.CategoriaDadosDTO;
+import com.projetointegrado.MeuBolso.dashboard.dto.CategoriaExpandedDTO;
+import com.projetointegrado.MeuBolso.dashboard.dto.CategoriaMinDTO;
 import com.projetointegrado.MeuBolso.globalExceptions.AcessoNegadoException;
 import com.projetointegrado.MeuBolso.globalExceptions.EntidadeNaoEncontradaException;
 import com.projetointegrado.MeuBolso.transacao.TipoTransacao;

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/ContaDashboardService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/ContaDashboardService.java
@@ -28,6 +28,8 @@ public class ContaDashboardService {
         while(!dataAvanco.isAfter(dataFinal)) {
             BigDecimal saldo = contaService.findSaldo(userId, dataAvanco).getSaldo();
             dtos.add(new SaldoBalancoDTO(dataAvanco.getYear(), dataAvanco.getMonthValue(), saldo));
+
+            dataAvanco = avancoMensal.avancarData(dataAvanco, dataInicial, 1);
         }
         return dtos;
     }

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/ContaDashboardService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/ContaDashboardService.java
@@ -1,0 +1,34 @@
+package com.projetointegrado.MeuBolso.dashboard;
+
+import com.projetointegrado.MeuBolso.conta.ContaRepository;
+import com.projetointegrado.MeuBolso.conta.ContaService;
+import com.projetointegrado.MeuBolso.dashboard.dto.SaldoBalancoDTO;
+import com.projetointegrado.MeuBolso.repetirTransacao.avancarData.AvancoDataFactory;
+import com.projetointegrado.MeuBolso.repetirTransacao.avancarData.IAvancoDataStrategy;
+import com.projetointegrado.MeuBolso.transacaoRecorrente.Periodicidade;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class ContaDashboardService {
+    @Autowired
+    private ContaService contaService;
+
+    public List<SaldoBalancoDTO> getBalancoSaldos(String userId, LocalDate dataInicial, LocalDate dataFinal) {
+        IAvancoDataStrategy avancoMensal = AvancoDataFactory.getStrategy(Periodicidade.MENSAL);
+        LocalDate dataAvanco = dataInicial.with(TemporalAdjusters.lastDayOfMonth());
+        List<SaldoBalancoDTO> dtos = new ArrayList<>();
+
+        while(!dataAvanco.isAfter(dataFinal)) {
+            BigDecimal saldo = contaService.findSaldo(userId, dataAvanco).getSaldo();
+            dtos.add(new SaldoBalancoDTO(dataAvanco.getYear(), dataAvanco.getMonthValue(), saldo));
+        }
+        return dtos;
+    }
+}

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/ContaDashboardService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/ContaDashboardService.java
@@ -22,7 +22,7 @@ public class ContaDashboardService {
 
     public List<SaldoBalancoDTO> getBalancoSaldos(String userId, LocalDate dataInicial, LocalDate dataFinal) {
         System.out.println("==============================> Gerar transacoes Balanco");
-        IAvancoDataStrategy avancoMensal = AvancoDataFactory.getStrategy(Periodicidade.MENSAL);
+        IAvancoDataStrategy avancoMensal = AvancoDataFactory.getStrategy(Periodicidade.ULTIMO_DIA_MES);
         LocalDate dataAvanco = dataInicial.with(TemporalAdjusters.lastDayOfMonth());
         List<SaldoBalancoDTO> dtos = new ArrayList<>();
         System.out.println("dataavanco: "+dataAvanco);

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/ContaDashboardService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/ContaDashboardService.java
@@ -21,14 +21,16 @@ public class ContaDashboardService {
     private ContaService contaService;
 
     public List<SaldoBalancoDTO> getBalancoSaldos(String userId, LocalDate dataInicial, LocalDate dataFinal) {
+        System.out.println("==============================> Gerar transacoes Balanco");
         IAvancoDataStrategy avancoMensal = AvancoDataFactory.getStrategy(Periodicidade.MENSAL);
         LocalDate dataAvanco = dataInicial.with(TemporalAdjusters.lastDayOfMonth());
         List<SaldoBalancoDTO> dtos = new ArrayList<>();
-
+        System.out.println("dataavanco: "+dataAvanco);
+        System.out.println("dataFinal:" + dataFinal);
         while(!dataAvanco.isAfter(dataFinal)) {
             BigDecimal saldo = contaService.findSaldo(userId, dataAvanco).getSaldo();
             dtos.add(new SaldoBalancoDTO(dataAvanco.getYear(), dataAvanco.getMonthValue(), saldo));
-
+            System.out.println("dataavanco: "+dataAvanco);
             dataAvanco = avancoMensal.avancarData(dataAvanco, dataInicial, 1);
         }
         return dtos;

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/ContaDashboardService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/ContaDashboardService.java
@@ -1,6 +1,5 @@
 package com.projetointegrado.MeuBolso.dashboard;
 
-import com.projetointegrado.MeuBolso.conta.ContaRepository;
 import com.projetointegrado.MeuBolso.conta.ContaService;
 import com.projetointegrado.MeuBolso.dashboard.dto.SaldoBalancoDTO;
 import com.projetointegrado.MeuBolso.repetirTransacao.avancarData.AvancoDataFactory;
@@ -8,6 +7,7 @@ import com.projetointegrado.MeuBolso.repetirTransacao.avancarData.IAvancoDataStr
 import com.projetointegrado.MeuBolso.transacaoRecorrente.Periodicidade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -20,7 +20,8 @@ public class ContaDashboardService {
     @Autowired
     private ContaService contaService;
 
-    public List<SaldoBalancoDTO> getBalancoSaldos(String userId, LocalDate dataInicial, LocalDate dataFinal) {
+    @Transactional
+    public List<SaldoBalancoDTO> findSaldosBalanco(String userId, LocalDate dataInicial, LocalDate dataFinal) {
         System.out.println("==============================> Gerar transacoes Balanco");
         IAvancoDataStrategy avancoMensal = AvancoDataFactory.getStrategy(Periodicidade.ULTIMO_DIA_MES);
         LocalDate dataAvanco = dataInicial.with(TemporalAdjusters.lastDayOfMonth());

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/DashboardController.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/DashboardController.java
@@ -1,12 +1,12 @@
-package com.projetointegrado.MeuBolso.dashBoards;
+package com.projetointegrado.MeuBolso.dashboard;
 
-import com.projetointegrado.MeuBolso.dashBoards.dto.TransacaoBalancoDTO;
-import com.projetointegrado.MeuBolso.dashBoards.dto.CategoriaExpandedDTO;
-import com.projetointegrado.MeuBolso.dashBoards.dto.CategoriaMinDTO;
+import com.projetointegrado.MeuBolso.dashboard.dto.SaldoBalancoDTO;
+import com.projetointegrado.MeuBolso.dashboard.dto.TransacaoBalancoDTO;
+import com.projetointegrado.MeuBolso.dashboard.dto.CategoriaExpandedDTO;
+import com.projetointegrado.MeuBolso.dashboard.dto.CategoriaMinDTO;
 import com.projetointegrado.MeuBolso.transacao.TipoTransacao;
 import com.projetointegrado.MeuBolso.usuario.UsuarioService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping(value ="/dashboards")
-public class DashBoardController {
+public class DashboardController {
     @Autowired
     private CategoriaDashboardService categoriaDashboardService;
 
@@ -24,6 +24,9 @@ public class DashBoardController {
 
     @Autowired
     private TransacoesDashboardsService transacoesDashboardsService;
+
+    @Autowired
+    private ContaDashboardService contaDashboardService;
 
     @GetMapping("/despesasCategoria")
     public List<CategoriaMinDTO> getDespesasCategorias(@RequestParam int ano, @RequestParam int mes){
@@ -61,6 +64,21 @@ public class DashBoardController {
 
             String userId = usuarioService.getUsuarioLogadoId();
             return transacoesDashboardsService.getTransacoesBalancos(userId, dataInicial, dataFinal);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @GetMapping("saldo/balanco")
+    public List<SaldoBalancoDTO> getBalancoSaldos(@RequestParam int anoInicial, @RequestParam int mesInicial, @RequestParam int anoFinal, @RequestParam int mesFinal) {
+        try {
+            LocalDate dataInicial = LocalDate.of(anoInicial, mesInicial, 1);
+            LocalDate dataFinal = LocalDate.of(anoFinal, mesFinal, 1);
+            dataFinal = dataFinal.with(TemporalAdjusters.lastDayOfMonth());
+            String userId = usuarioService.getUsuarioLogadoId();
+
+            return contaDashboardService.getBalancoSaldos(userId, dataInicial, dataFinal);
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException(e);

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/DashboardController.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/DashboardController.java
@@ -63,7 +63,7 @@ public class DashboardController {
             dataFinal = dataFinal.with(TemporalAdjusters.lastDayOfMonth());
 
             String userId = usuarioService.getUsuarioLogadoId();
-            return transacoesDashboardsService.getTransacoesBalancos(userId, dataInicial, dataFinal);
+            return transacoesDashboardsService.findTransacoesBalanco(userId, dataInicial, dataFinal);
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException(e);
@@ -78,7 +78,7 @@ public class DashboardController {
             dataFinal = dataFinal.with(TemporalAdjusters.lastDayOfMonth());
             String userId = usuarioService.getUsuarioLogadoId();
 
-            return contaDashboardService.getBalancoSaldos(userId, dataInicial, dataFinal);
+            return contaDashboardService.findSaldosBalanco(userId, dataInicial, dataFinal);
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException(e);

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/TransacoesDashboardsService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/TransacoesDashboardsService.java
@@ -25,7 +25,7 @@ public class TransacoesDashboardsService {
 
     public List<TransacaoBalancoDTO> getTransacoesBalancos(String userId, LocalDate dataInicial, LocalDate dataFinal) {
         System.out.println("==============================> Gerar transacoes Balanco");
-        IAvancoDataStrategy avancoMensal = AvancoDataFactory.getStrategy(Periodicidade.MENSAL);
+        IAvancoDataStrategy avancoMensal = AvancoDataFactory.getStrategy(Periodicidade.ULTIMO_DIA_MES);
         LocalDate dataAvanco = dataInicial.with(TemporalAdjusters.lastDayOfMonth());
         List<TransacaoBalancoDTO> dtos = new ArrayList<>();
         System.out.println("dataavanco: "+dataAvanco);

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/TransacoesDashboardsService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/TransacoesDashboardsService.java
@@ -8,6 +8,7 @@ import com.projetointegrado.MeuBolso.transacao.TransacaoService;
 import com.projetointegrado.MeuBolso.transacaoRecorrente.Periodicidade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -23,7 +24,8 @@ public class TransacoesDashboardsService {
     @Autowired
     private TransacaoService transacaoService;
 
-    public List<TransacaoBalancoDTO> getTransacoesBalancos(String userId, LocalDate dataInicial, LocalDate dataFinal) {
+    @Transactional
+    public List<TransacaoBalancoDTO> findTransacoesBalanco(String userId, LocalDate dataInicial, LocalDate dataFinal) {
         System.out.println("==============================> Gerar transacoes Balanco");
         IAvancoDataStrategy avancoMensal = AvancoDataFactory.getStrategy(Periodicidade.ULTIMO_DIA_MES);
         LocalDate dataAvanco = dataInicial.with(TemporalAdjusters.lastDayOfMonth());

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/TransacoesDashboardsService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/TransacoesDashboardsService.java
@@ -1,6 +1,6 @@
-package com.projetointegrado.MeuBolso.dashBoards;
+package com.projetointegrado.MeuBolso.dashboard;
 
-import com.projetointegrado.MeuBolso.dashBoards.dto.TransacaoBalancoDTO;
+import com.projetointegrado.MeuBolso.dashboard.dto.TransacaoBalancoDTO;
 import com.projetointegrado.MeuBolso.repetirTransacao.avancarData.AvancoDataFactory;
 import com.projetointegrado.MeuBolso.repetirTransacao.avancarData.IAvancoDataStrategy;
 import com.projetointegrado.MeuBolso.transacao.TransacaoRepository;

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/dto/CategoriaDadosDTO.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/dto/CategoriaDadosDTO.java
@@ -1,4 +1,4 @@
-package com.projetointegrado.MeuBolso.dashBoards.dto;
+package com.projetointegrado.MeuBolso.dashboard.dto;
 
 import com.projetointegrado.MeuBolso.categoria.Categoria;
 

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/dto/CategoriaExpandedDTO.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/dto/CategoriaExpandedDTO.java
@@ -1,4 +1,4 @@
-package com.projetointegrado.MeuBolso.dashBoards.dto;
+package com.projetointegrado.MeuBolso.dashboard.dto;
 
 import com.projetointegrado.MeuBolso.transacao.dto.TransacaoDTO;
 

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/dto/CategoriaMinDTO.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/dto/CategoriaMinDTO.java
@@ -1,4 +1,4 @@
-package com.projetointegrado.MeuBolso.dashBoards.dto;
+package com.projetointegrado.MeuBolso.dashboard.dto;
 
 import java.math.BigDecimal;
 

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/dto/SaldoBalancoDTO.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/dto/SaldoBalancoDTO.java
@@ -1,0 +1,10 @@
+package com.projetointegrado.MeuBolso.dashboard.dto;
+
+import java.math.BigDecimal;
+
+public record SaldoBalancoDTO(
+        int ano,
+        int mes,
+        BigDecimal saldo
+) {
+}

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/dto/TransacaoBalancoDTO.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/dashboard/dto/TransacaoBalancoDTO.java
@@ -1,4 +1,4 @@
-package com.projetointegrado.MeuBolso.dashBoards.dto;
+package com.projetointegrado.MeuBolso.dashboard.dto;
 
 import java.math.BigDecimal;
 

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/repetirTransacao/TransacaoRepeticaoAspect.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/repetirTransacao/TransacaoRepeticaoAspect.java
@@ -16,7 +16,9 @@ public class TransacaoRepeticaoAspect {
         this.transacaoRepeticaoExecutor = transacaoRepeticaoExecutor;
     }
 
-    @Before("execution(* com.projetointegrado.MeuBolso.conta.ContaService.find*(..)) || execution(* com.projetointegrado.MeuBolso.transacao.TransacaoService.findAll*(..)) || execution(* com.projetointegrado.MeuBolso.transacao.TransacaoService.findSum*(..))")
+    @Before("execution(* com.projetointegrado.MeuBolso.conta.ContaService.find*(..)) || execution(* com.projetointegrado.MeuBolso.transacao.TransacaoService.findAll*(..)) " +
+            "|| execution(* com.projetointegrado.MeuBolso.transacao.TransacaoService.findSum*(..)) || execution(* com.projetointegrado.MeuBolso.dashboard.CategoriaDashboardService.find*(..))" +
+            "|| execution(* com.projetointegrado.MeuBolso.dashboard.ContaDashboardService.find*(..)) || execution(* com.projetointegrado.MeuBolso.dashboard.TransacoesDashboardsService.find*(..))")
     public void gerarTransacoesFixasAntesDasBuscas(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
         LocalDate data = null;

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/repetirTransacao/avancarData/AvancoDataFactory.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/repetirTransacao/avancarData/AvancoDataFactory.java
@@ -11,6 +11,8 @@ public class AvancoDataFactory {
                 return new AvancoSemanal();
             case MENSAL:
                 return new AvancoMensal();
+            case ULTIMO_DIA_MES:
+                return new AvancoUltimoIDiaMes();
             default:
                 throw new IllegalArgumentException("Periodicidade desconhecida");
         }

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/repetirTransacao/avancarData/AvancoUltimoIDiaMes.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/repetirTransacao/avancarData/AvancoUltimoIDiaMes.java
@@ -1,0 +1,12 @@
+package com.projetointegrado.MeuBolso.repetirTransacao.avancarData;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+
+public class AvancoUltimoIDiaMes implements IAvancoDataStrategy{
+    @Override
+    public LocalDate avancarData(LocalDate dataAtual, LocalDate dataCadastro, Integer qtdAvancos) {
+        LocalDate proximaData = dataAtual.plusMonths(qtdAvancos);
+        return proximaData.with(TemporalAdjusters.lastDayOfMonth());
+    }
+}

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/Periodicidade.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/Periodicidade.java
@@ -1,5 +1,5 @@
 package com.projetointegrado.MeuBolso.transacaoRecorrente;
 
 public enum Periodicidade {
-    DIARIO, SEMANAL, MENSAL
+    DIARIO, SEMANAL, MENSAL, ULTIMO_DIA_MES
 }


### PR DESCRIPTION
Adicionei os dados necessários para a produção do gráfico de saldo mensal de acordo com um perído.
Rota:
- /dashboards/transacoes/balanco

ex:
/dashboards/saldo/balanco?anoInicial=2025&mesInicial=1&anoFinal=2025&mesFinal=12
ele retorna dados no formato:
[
	{
		"ano": 2025,
		"mes": 1,
		"saldo": 953.59
	},
	{
		"ano": 2025,
		"mes": 2,
		"saldo": 920.18
	}, ...
]

gráfico de referência do protótipo:
![image](https://github.com/user-attachments/assets/ed677447-5f4c-44e5-a71c-5ca454b821a7)
