### PR TITLE
Removendo data de depósito inicial e adicionando validação em POST e PUT conta

### DIFF
--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/Conta.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/Conta.java
@@ -40,22 +40,22 @@ public class Conta {
     @JoinColumn(nullable = false, name = "usuario_id")
     private Usuario usuario;
 
+    @Column(nullable = false)
+    private BigDecimal saldoInicial;
+
     @OneToMany(mappedBy = "conta", cascade = CascadeType.REMOVE, fetch = FetchType.EAGER)
     private List<Transacao> transacoes;
 
     @OneToMany(mappedBy = "conta", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private List<TransacaoRecorrente> transacoesRecorrentes;
 
-   // @Transient //indica que o valor não será persistido no banco de dados.
-    //private Date dataAtual;
 
-    //mapear as transacoes_recorrentes aqui.
-
-    public Conta(Long id, TipoConta tipo_conta, Banco banco, String descricao, Usuario usuario) {
+    public Conta(Long id, TipoConta tipo_conta, Banco banco, String descricao, BigDecimal saldoInicial ,Usuario usuario) {
         this.id = id;
         this.tipo_conta = tipo_conta;
         this.banco = banco;
         this.descricao = descricao;
+        this.saldoInicial = saldoInicial;
         this.usuario = usuario;
         this.transacoes = new ArrayList<>();
     }
@@ -76,7 +76,7 @@ public class Conta {
     }
 
     public BigDecimal getSaldo(LocalDate data) {
-        BigDecimal saldo = BigDecimal.ZERO;
+        BigDecimal saldo = saldoInicial;
         if (transacoes == null || transacoes.isEmpty()) return saldo;
         for (Transacao transacao : transacoes) {
             if (!transacao.getData().isAfter(data)) { //retorna true para todas as datas antes de data
@@ -88,9 +88,6 @@ public class Conta {
         }
         return saldo;
     }
-//    public void setSaldo(BigDecimal saldo) {
-//        this.saldo = saldo; //tirar essa lógica depois.
-//    }
 
     public TipoConta getTipo_conta() {
         return tipo_conta;
@@ -123,14 +120,6 @@ public class Conta {
     public void setTransacoes(List<Transacao> transacoes) {
         this.transacoes = transacoes;
     }
-
-//    public Date getDataAtual() {
-//        return dataAtual;
-//    }
-//
-//    public void setDataAtual(Date dataAtual) {
-//        this.dataAtual = dataAtual;
-//    }
 
     public String getDescricao() {
         return descricao;

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/ContaController.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/ContaController.java
@@ -1,10 +1,13 @@
 package com.projetointegrado.MeuBolso.conta;
 
 import com.projetointegrado.MeuBolso.conta.dto.*;
+import com.projetointegrado.MeuBolso.globalExceptions.ValoresNaoPermitidosException;
 import com.projetointegrado.MeuBolso.usuario.IUsuarioService;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -60,13 +63,19 @@ public class ContaController {
     }
 
     @PostMapping
-    public ContaDTO save(@RequestBody ContaPostDTO contaPostDTO){ //adicionar @Valid depois.
+    public ContaDTO save(@RequestBody @Valid ContaPostDTO contaPostDTO, BindingResult bindingResult){
+        if (bindingResult.hasErrors()) {
+            throw new ValoresNaoPermitidosException(bindingResult);
+        }
         String userId = usuarioService.getUsuarioLogadoId();
         return contaService.save(userId, contaPostDTO);
     }
 
     @PutMapping("/{id}")
-    public ContaDTO update(@PathVariable Long id, @RequestBody ContaPutDTO contaPostDTO){ //aterar para criar transacao de correcao de valor
+    public ContaDTO update(@PathVariable Long id, @RequestBody @Valid ContaPutDTO contaPostDTO, BindingResult bindingResult){
+        if (bindingResult.hasErrors()){
+            throw new ValoresNaoPermitidosException(bindingResult);
+        }
         String userId = usuarioService.getUsuarioLogadoId();
         return contaService.update(id, contaPostDTO, userId);
     }

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/ContaService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/ContaService.java
@@ -105,15 +105,8 @@ public class ContaService implements IContaService {
 
         if(contaRepository.findByDescricao(userID, dto.getDescricao()) != null) throw new DescricaoJaExistenteException();
 
-        Conta conta = new Conta(null, tipo, banco, dto.getDescricao(), usuario);
+        Conta conta = new Conta(null, tipo, banco, dto.getDescricao(), dto.getSaldo(), usuario);
         conta = contaRepository.save(conta);
-        Categoria categoria = categoriaRepository.findByName(userID,"DepositoInicial*");
-        try {
-            TransacaoDTO transacaodto = transacaoService.save(userID, new TransacaoSaveDTO(dto.getSaldo(), dto.getData(), "RECEITA", categoria.getId(), conta.getId(), "DepositoInicial"));
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
         return new ContaDTO(conta);
     }
 

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/dto/ContaPostDTO.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/dto/ContaPostDTO.java
@@ -4,10 +4,10 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public class ContaPostDTO {
+
     private BigDecimal saldo;
     private Long id_banco;
     private Long id_tipo_conta;
-    private LocalDate data;
     private String descricao;
 
     public String getDescricao() {
@@ -16,14 +16,6 @@ public class ContaPostDTO {
 
     public void setDescricao(String descricao) {
         this.descricao = descricao;
-    }
-
-    public LocalDate getData() {
-        return data;
-    }
-
-    public void setData(LocalDate data) {
-        this.data = data;
     }
 
     public BigDecimal getSaldo() {

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/dto/ContaPostDTO.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/dto/ContaPostDTO.java
@@ -3,42 +3,5 @@ package com.projetointegrado.MeuBolso.conta.dto;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-public class ContaPostDTO {
-
-    private BigDecimal saldo;
-    private Long id_banco;
-    private Long id_tipo_conta;
-    private String descricao;
-
-    public String getDescricao() {
-        return descricao;
-    }
-
-    public void setDescricao(String descricao) {
-        this.descricao = descricao;
-    }
-
-    public BigDecimal getSaldo() {
-        return saldo;
-    }
-
-    public void setSaldo(BigDecimal saldo) {
-        this.saldo = saldo;
-    }
-
-    public Long getId_banco() {
-        return id_banco;
-    }
-
-    public void setId_banco(Long id_banco) {
-        this.id_banco = id_banco;
-    }
-
-    public Long getId_tipo_conta() {
-        return id_tipo_conta;
-    }
-
-    public void setId_tipo_conta(Long id_tipo_conta) {
-        this.id_tipo_conta = id_tipo_conta;
-    }
+public class ContaPostDTO extends ContaSaveDTO{
 }

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/dto/ContaPutDTO.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/dto/ContaPutDTO.java
@@ -1,53 +1,18 @@
 package com.projetointegrado.MeuBolso.conta.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-public class ContaPutDTO {
-    private BigDecimal saldo;
-    private Long id_banco;
-    private Long id_tipo_conta;
+public class ContaPutDTO extends ContaSaveDTO{
+    @NotNull(message = "Data não pode ser vazia")
     private LocalDate data;
-    private String descricao;
-
 
     public LocalDate getData() {
         return data;
     }
-
     public void setData(LocalDate data) {
         this.data = data;
-    }
-
-    public String getDescricao() {
-        return descricao;
-    }
-
-    public void setDescricao(String descricao) {
-        this.descricao = descricao;
-    }
-
-    public BigDecimal getSaldo() {
-        return saldo;
-    }
-
-    public void setSaldo(BigDecimal saldo) {
-        this.saldo = saldo;
-    }
-
-    public Long getId_banco() {
-        return id_banco;
-    }
-
-    public void setId_banco(Long id_banco) {
-        this.id_banco = id_banco;
-    }
-
-    public Long getId_tipo_conta() {
-        return id_tipo_conta;
-    }
-
-    public void setId_tipo_conta(Long id_tipo_conta) {
-        this.id_tipo_conta = id_tipo_conta;
     }
 }

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/dto/ContaSaveDTO.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/dto/ContaSaveDTO.java
@@ -18,7 +18,6 @@ public abstract class ContaSaveDTO {
     @NotNull(message = "Tipo da conta não pode ser vazio")
     private Long id_tipo_conta;
 
-    @NotNull(message = "Descrição não pode ser vazia")
     @NotBlank(message = "Descrição não pode ser vazia")
     private String descricao;
 

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/dto/ContaSaveDTO.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/conta/dto/ContaSaveDTO.java
@@ -1,0 +1,56 @@
+package com.projetointegrado.MeuBolso.conta.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public abstract class ContaSaveDTO {
+
+    @NotNull(message = "Saldo não pode ser vazio")
+    @DecimalMin(value = "0.01", message = "O valor do saldo deve ser no mínimo 0.01")
+    private BigDecimal saldo;
+
+    @NotNull(message = "Banco não pode ser vazio")
+    private Long id_banco;
+
+    @NotNull(message = "Tipo da conta não pode ser vazio")
+    private Long id_tipo_conta;
+
+    @NotNull(message = "Descrição não pode ser vazia")
+    @NotBlank(message = "Descrição não pode ser vazia")
+    private String descricao;
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public BigDecimal getSaldo() {
+        return saldo;
+    }
+
+    public void setSaldo(BigDecimal saldo) {
+        this.saldo = saldo;
+    }
+
+    public Long getId_banco() {
+        return id_banco;
+    }
+
+    public void setId_banco(Long id_banco) {
+        this.id_banco = id_banco;
+    }
+
+    public Long getId_tipo_conta() {
+        return id_tipo_conta;
+    }
+
+    public void setId_tipo_conta(Long id_tipo_conta) {
+        this.id_tipo_conta = id_tipo_conta;
+    }
+}

--- a/back/MeuBolso/src/main/resources/import.sql
+++ b/back/MeuBolso/src/main/resources/import.sql
@@ -13,8 +13,8 @@ insert into banco (nome, icone_url) values ('Bradesco', 'https://play-lh.googleu
 insert into banco (nome, icone_url) values ('Banco do Brasil', 'https://play-lh.googleusercontent.com/1-aNhsSPNqiVluwNGZar_7F5PbQ4u1zteuJ1jumnArhe8bfYHHaVwu4aVOF5-NAmLaA');
 insert into banco (nome, icone_url) values ('Nubank', 'https://t.ctcdn.com.br/DIEw0gGtQl_GNhWXJwgrRmuGpIk=/i624750.png');
 /*CONTA*/
-insert into conta(tipo_conta_id, banco_id, usuario_id, descricao) values ('1', '3', '2ebbc2f1-bf81-470c-a5f2-063723d99d2c', 'conta01');
-insert into conta(tipo_conta_id, banco_id, usuario_id, descricao) values ('3', '1', '2ebbc2f1-bf81-470c-a5f2-063723d99d2c', 'conta02');
+insert into conta(tipo_conta_id, banco_id, usuario_id, descricao, saldo_inicial) values ('1', '3', '2ebbc2f1-bf81-470c-a5f2-063723d99d2c', 'conta01', '10');
+insert into conta(tipo_conta_id, banco_id, usuario_id, descricao, saldo_inicial) values ('3', '1', '2ebbc2f1-bf81-470c-a5f2-063723d99d2c', 'conta02', '0');
 
 /*CATEGORIAS*/
 insert into categoria (nome, tipo_categoria, cor, usuario_id) values ('casa', 'despesa', '8755BC', '2ebbc2f1-bf81-470c-a5f2-063723d99d2c');             /*1*/


### PR DESCRIPTION
Back-end deixa de criar transação inicial para depósito, ao invés disso o saldo inicial é adicionado a uma coluna na tabela de conta e todas as somas são feitas com base nela.
Rota de POST:
```
http://localhost:8080/contas
```
body: 
```
{
    "saldo": 187.00,
    "id_banco": 3,
    "id_tipo_conta": 1,
    "descricao": "conta01"
}
```

A Rota de PUT ainda necessita de uma data para criar uma transação de reajsute de saldo caso necessário e portanto, permanece inalterada.

Foram adicionadas validações sobre as entradas de ambas as rotas com emissões de erro descritivas para o usuário.