### PR TITLE
Add funcionalidades de deleção para trasnsações fixas

### DIFF
--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/repetirTransacao/TransacaoRepeticaoAspect.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/repetirTransacao/TransacaoRepeticaoAspect.java
@@ -19,7 +19,7 @@ public class TransacaoRepeticaoAspect {
     @Before("execution(* com.projetointegrado.MeuBolso.conta.ContaService.find*(..)) || execution(* com.projetointegrado.MeuBolso.transacao.TransacaoService.findAll*(..)) " +
             "|| execution(* com.projetointegrado.MeuBolso.transacao.TransacaoService.findSum*(..)) || execution(* com.projetointegrado.MeuBolso.dashboard.CategoriaDashboardService.find*(..))" +
             "|| execution(* com.projetointegrado.MeuBolso.dashboard.ContaDashboardService.find*(..)) || execution(* com.projetointegrado.MeuBolso.dashboard.TransacoesDashboardsService.find*(..))")
-    public void gerarTransacoesFixasAntesDasBuscas(JoinPoint joinPoint) {
+    public void gerarTransacoesRecorrentes(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
         LocalDate data = null;
         String usuarioId = null;

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/repetirTransacao/TransacaoRepeticaoAspect.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/repetirTransacao/TransacaoRepeticaoAspect.java
@@ -34,7 +34,7 @@ public class TransacaoRepeticaoAspect {
 
         if (data != null && usuarioId != null) {
             System.out.println("AOP -> Gerando transações fixas para usuário ID " + usuarioId + " e data " + data);
-            transacaoRepeticaoExecutor.executarGeracaoTransacoes(data, usuarioId); // ✅ Agora sempre executa em nova transação
+            transacaoRepeticaoExecutor.executarGeracaoTransacoes(data, usuarioId);
         } else {
             System.out.println("AOP -> Parâmetros não encontrados, pulando geração de transações.");
         }

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/repetirTransacao/TransacaoRepeticaoService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/repetirTransacao/TransacaoRepeticaoService.java
@@ -24,13 +24,12 @@ public class TransacaoRepeticaoService {
     @Autowired
     private GerarTransacoesFactory gerarTransacoesFactory;
 
-    public List<Transacao> gerarTransacoes(LocalDate data, String userId) {
+    public void gerarTransacoes(LocalDate data, String userId) {
         // Obtém todas as transações normais no período
         System.out.println("TransacaoRecorrenteService -> gerarTransacoes");
-        List<Transacao> transacoesNormais = transacaoRepository.findAllBeforeDate(data, userId);
 
         List<TransacaoRecorrente> transacoesRecorrentes = transacaoRecorrenteRepository.findAllByUsuario(userId);
-        if (transacoesNormais.isEmpty() || transacoesRecorrentes.isEmpty()) return null;
+        if (transacoesRecorrentes.isEmpty()) return;
         try {
             for (TransacaoRecorrente transacaoRecorrente : transacoesRecorrentes) {
                 if (!transacaoRecorrente.getAtiva()) continue;
@@ -41,6 +40,5 @@ public class TransacaoRepeticaoService {
             e.printStackTrace();
             throw new RuntimeException(e);
         }
-        return transacoesNormais;
     }
 }

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacao/Transacao.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacao/Transacao.java
@@ -51,7 +51,7 @@ public class Transacao {
     private Usuario usuario;
 
     @ManyToOne(optional = true)
-    @JoinColumn(name = "transacao_fixa_id")
+    @JoinColumn(name = "transacao_recorrente_id")
     private TransacaoRecorrente transacaoRecorrente;
 
     @Enumerated(EnumType.STRING)

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacao/Transacao.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacao/Transacao.java
@@ -94,11 +94,11 @@ public class Transacao {
     }
 
     // Getters e Setters
-    public TransacaoRecorrente getTransacaoFixa() {
+    public TransacaoRecorrente getTransacaoRecorrente() {
         return transacaoRecorrente;
     }
 
-    public void setTransacaoFixa(TransacaoRecorrente transacaoRecorrente) {
+    public void setTransacaoRecorrente(TransacaoRecorrente transacaoRecorrente) {
         this.transacaoRecorrente = transacaoRecorrente;
     }
 

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacao/TransacaoRepository.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacao/TransacaoRepository.java
@@ -57,7 +57,7 @@ public interface TransacaoRepository extends JpaRepository<Transacao, Long> {
         from transacao as t,
              categoria as c
         where c.id = t.categoria_id
-              and t.usuario_id = :userId 
+              and t.usuario_id = :userId  
               and t.tipo = :tipo 
               and t.data between :dataInicio and :dataFim
               and c.interna_sistema = false;

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacao/dto/TransacaoDTO.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacao/dto/TransacaoDTO.java
@@ -19,6 +19,7 @@ public class TransacaoDTO {
     private String comentario;
     private String descricao;
     private String origem;
+    private Long idTransacaoRecorrente;
 
     public TransacaoDTO(Transacao transacao) {
         this.id = transacao.getId();
@@ -30,6 +31,8 @@ public class TransacaoDTO {
         this.comentario = transacao.getComentario();
         this.descricao = transacao.getDescricao();
         this.origem = transacao.getOrigemTransacao().name();
+        if (transacao.getTransacaoRecorrente() != null)
+            this.idTransacaoRecorrente = transacao.getTransacaoRecorrente().getId();
     }
 
     public TransacaoDTO(TransacaoMeta transacao) {
@@ -115,6 +118,14 @@ public class TransacaoDTO {
 
     public void setOrigem(String origem) {
         this.origem = origem;
+    }
+
+    public Long getIdTransacaoRecorrente() {
+        return idTransacaoRecorrente;
+    }
+
+    public void setIdTransacaoRecorrente(Long idTransacaoRecorrente) {
+        this.idTransacaoRecorrente = idTransacaoRecorrente;
     }
 
     @Override

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/ITransacaoRecorrenteService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/ITransacaoRecorrenteService.java
@@ -3,6 +3,7 @@ package com.projetointegrado.MeuBolso.transacaoRecorrente;
 import com.projetointegrado.MeuBolso.transacaoRecorrente.dto.TransacaoRecorrenteDTO;
 import com.projetointegrado.MeuBolso.transacaoRecorrente.dto.ITransacaoRecorrenteDTO;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ITransacaoRecorrenteService {
@@ -12,5 +13,6 @@ public interface ITransacaoRecorrenteService {
     public TransacaoRecorrenteDTO save(String userId, ITransacaoRecorrenteDTO dto);
     public TransacaoRecorrenteDTO update(String userId, Long id, ITransacaoRecorrenteDTO dto);
     public TransacaoRecorrenteDTO delete(String userId, Long id);
+    public TransacaoRecorrenteDTO deleteAllAfterDate(String userId, Long id, LocalDate data);
     public TransacaoRecorrenteDTO atualizarStatusAtiva(String usuarioId, Long id, Boolean ativa);
 }

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/TransacaoRecorrente.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/TransacaoRecorrente.java
@@ -58,6 +58,7 @@ public class TransacaoRecorrente {
     private Integer qtdParcelas;
 
     @Column(nullable = false, name = "tipo_repeticao")
+    @Enumerated(EnumType.STRING)
     private TipoRepeticao tipoRepeticao;
 
     @OneToMany(mappedBy = "transacaoRecorrente", cascade = CascadeType.REMOVE)

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/TransacaoRecorrenteController.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/TransacaoRecorrenteController.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController()
@@ -98,7 +99,14 @@ public class TransacaoRecorrenteController {
         return transacaoRecorrenteService.delete(userId, id);
     }
 
-    @Operation(summary = "Atualiza o status de ativo de uma transacao recorrente, fixa ou parcelada (permitindo assim o 'soft delete')")
+    @Operation(summary = "desativa uma transação fixa e recebe uma data. Apaga todas as transações relacionadas a essa transação fixa depois da data recebida")
+    @DeleteMapping("/futuras/{id}")
+    public TransacaoRecorrenteDTO deleteFuturas(@PathVariable Long id, @RequestParam LocalDate data){
+        String userId = usuarioService.getUsuarioLogadoId();
+        return transacaoRecorrenteService.deleteAllAfterDate(userId, id, data);
+    }
+
+    @Operation(summary = "Atualiza o status de ativo de uma transacao recorrente, fixa ou parcelada (permitindo assim o 'soft delete'). Permite ativar e reativar uma transação fixa")
     @PatchMapping("/arquivadas/{id}")
     public TransacaoRecorrenteDTO atualizarStatusAtiva(@PathVariable Long id, @RequestBody ArquivarCategoriaPatchDTO dto, BindingResult bindingResult) throws ValoresNaoPermitidosException {
         if (bindingResult.hasErrors()) {

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/TransacaoRecorrenteRepository.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/TransacaoRecorrenteRepository.java
@@ -1,8 +1,11 @@
 package com.projetointegrado.MeuBolso.transacaoRecorrente;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface TransacaoRecorrenteRepository extends JpaRepository<TransacaoRecorrente, Long> {
@@ -21,4 +24,13 @@ public interface TransacaoRecorrenteRepository extends JpaRepository<TransacaoRe
         order by (data_cadastro) desc;
     """)
     public List<TransacaoRecorrente> findAllArquivadasByUsuario(String userId);
+
+    @Modifying
+    @Transactional
+    @Query(nativeQuery = true, value = """
+        delete from TRANSACAO
+        where transacao_recorrente_id = :id
+        and data > :data
+    """)
+    public void deleteAllAfterDate(Long id, LocalDate data);
 }

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/TransacaoRecorrenteRepository.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/TransacaoRecorrenteRepository.java
@@ -30,7 +30,7 @@ public interface TransacaoRecorrenteRepository extends JpaRepository<TransacaoRe
     @Query(nativeQuery = true, value = """
         delete from TRANSACAO
         where transacao_recorrente_id = :id
-        and data > :data
+        and data >= :data
     """)
     public void deleteAllAfterDate(Long id, LocalDate data);
 }

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/TransacaoRecorrenteService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/TransacaoRecorrenteService.java
@@ -84,12 +84,8 @@ public class TransacaoRecorrenteService implements ITransacaoRecorrenteService {
         this.atualizarStatusAtiva(userId, id, false);
         TransacaoRecorrente transacao = transacaoRecorrenteValidateService.validateAndGet(id, userId, new EntidadeNaoEncontradaException("/{id}", "TransacaoRecorrente nao encontrada"), new AcessoNegadoException());
         TransacaoRecorrenteDTO dto = new TransacaoRecorrenteDTO(transacao);
-        try {
-            transacaoRecorrenteRepository.deleteAllAfterDate(id, data);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+
+        transacaoRecorrenteRepository.deleteAllAfterDate(id, data);
         return dto;
     }
 

--- a/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/TransacaoRecorrenteService.java
+++ b/back/MeuBolso/src/main/java/com/projetointegrado/MeuBolso/transacaoRecorrente/TransacaoRecorrenteService.java
@@ -17,6 +17,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @EnableScheduling
@@ -75,6 +76,20 @@ public class TransacaoRecorrenteService implements ITransacaoRecorrenteService {
                 new EntidadeNaoEncontradaException("/{id}", "TransacaoRecorrente nao encontrada"), new AcessoNegadoException());
         TransacaoRecorrenteDTO dto = new TransacaoRecorrenteDTO(transacaoRecorrente);
         transacaoRecorrenteRepository.delete(transacaoRecorrente);
+        return dto;
+    }
+
+    @Transactional
+    public TransacaoRecorrenteDTO deleteAllAfterDate(String userId, Long id, LocalDate data) {
+        this.atualizarStatusAtiva(userId, id, false);
+        TransacaoRecorrente transacao = transacaoRecorrenteValidateService.validateAndGet(id, userId, new EntidadeNaoEncontradaException("/{id}", "TransacaoRecorrente nao encontrada"), new AcessoNegadoException());
+        TransacaoRecorrenteDTO dto = new TransacaoRecorrenteDTO(transacao);
+        try {
+            transacaoRecorrenteRepository.deleteAllAfterDate(id, data);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
         return dto;
     }
 


### PR DESCRIPTION
- Agora a informação do id da transação fixa referente é retornada juntamente com cada transação, caso não haja chave estrangeira desse tipo, é retornando null. Ex de retorno:
```
"idTransacaoRecorrente": 2
``` 
- Add rota para apagar a transação recorrente de uma determinada data e as próximas:
Ex:
```
http://localhost:8080/transacoesRecorrentes/futuras/1?data=2025-04-30
```
- Bug de gerar transações fixas sem ter uma transação cadastrada normal cadastrada antes.